### PR TITLE
Fix asset attribute setting

### DIFF
--- a/cli/src/main/groovy/NexusPublisher.groovy
+++ b/cli/src/main/groovy/NexusPublisher.groovy
@@ -57,7 +57,7 @@ toMap(options.Cs).each { component.addAttribute(it.key, it.value) }
 
 // set asset attributes
 asset = new DefaultAsset(options.filename.name, options.filename.newInputStream())
-toMap(options.As).each { component.addAttribute(it.key, it.value) }
+toMap(options.As).each { asset.addAttribute(it.key, it.value) }
 component.addAsset(asset)
 
 // upload to nexus repository


### PR DESCRIPTION
The asset attribute from the CLI args was being set on the `component` and not the `asset`