### PR TITLE
INT-2218 fix setup.sh and workspace path bugs

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -78,16 +78,29 @@ commands:
         steps:
           - attach_workspace:
               at: << parameters.workspace >>
-    - run: >
-        [[ -r setup.sh ]] && . setup.sh ;
-        groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
-        --username << parameters.username >>
-        --password << parameters.password >>
-        --serverurl << parameters.serverurl >>
-        --filename << parameters.workspace >>/<< parameters.filename >>
-        --format << parameters.format >>
-        --repository << parameters.repository >>
-        << parameters.attributes >>
+          - run: >
+              [[ -r setup.sh ]] && . setup.sh ;
+              groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
+              --username << parameters.username >>
+              --password << parameters.password >>
+              --serverurl << parameters.serverurl >>
+              --filename << parameters.workspace >>/<< parameters.filename >>
+              --format << parameters.format >>
+              --repository << parameters.repository >>
+              << parameters.attributes >>
+    - unless:
+        condition: << parameters.workspace >>
+        steps:
+          - run: >
+              [[ -r setup.sh ]] && . setup.sh ;
+              groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
+              --username << parameters.username >>
+              --password << parameters.password >>
+              --serverurl << parameters.serverurl >>
+              --filename << parameters.filename >>
+              --format << parameters.format >>
+              --repository << parameters.repository >>
+              << parameters.attributes >>
 
 jobs:
   nexusjob:

--- a/orb.yml
+++ b/orb.yml
@@ -78,29 +78,16 @@ commands:
         steps:
           - attach_workspace:
               at: << parameters.workspace >>
-          - run: >
-              [[ -r setup.sh ]] && . setup.sh ;
-              groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
-              --username << parameters.username >>
-              --password << parameters.password >>
-              --serverurl << parameters.serverurl >>
-              --filename << parameters.workspace >>/<< parameters.filename >>
-              --format << parameters.format >>
-              --repository << parameters.repository >>
-              << parameters.attributes >>
-    - unless:
-        condition: << parameters.workspace >>
-        steps:
-          - run: >
-              [[ -r setup.sh ]] && . setup.sh ;
-              groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
-              --username << parameters.username >>
-              --password << parameters.password >>
-              --serverurl << parameters.serverurl >>
-              --filename << parameters.filename >>
-              --format << parameters.format >>
-              --repository << parameters.repository >>
-              << parameters.attributes >>
+    - run: >
+        [[ -r setup.sh ]] && . setup.sh ;
+        groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
+        --username << parameters.username >>
+        --password << parameters.password >>
+        --serverurl << parameters.serverurl >>
+        --filename $(if [ ! -z "<< parameters.workspace >>" ] ; then echo << parameters.workspace >>/ ; fi)<< parameters.filename >>
+        --format << parameters.format >>
+        --repository << parameters.repository >>
+        << parameters.attributes >>
 
 jobs:
   nexusjob:

--- a/orb.yml
+++ b/orb.yml
@@ -79,7 +79,7 @@ commands:
           - attach_workspace:
               at: << parameters.workspace >>
     - run: >
-        [[ -r setup.sh ]] && . setup.sh &&
+        [[ -r setup.sh ]] && . setup.sh ;
         groovy << parameters.sonatypedir >>/bin/NexusPublisher.groovy
         --username << parameters.username >>
         --password << parameters.password >>


### PR DESCRIPTION
#### Description
This fixes as bug where build is not started when setup.sh is not present. presence of setup.sh is optional.
Also fixes a bug where the workspace and filename strings are not joined correctly.