### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -1,8 +1,10 @@
 version: 2.1
 description: >
   Sonatype Nexus Platform Integration. This Orb allows publishing of build
-  artifacts to Nexus Repository Manager instances. The source for this Orb is
-  available at: https://github.com/sonatype-nexus-community/circleci-nexus-orb
+  artifacts to Nexus Repository Manager instances.
+display:
+  source_url: https://github.com/sonatype-nexus-community/circleci-nexus-orb
+  home_url: https://www.sonatype.com/
 
 executors:
   nexus-platform-cli:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.